### PR TITLE
Change Dockerfile to use npm install instead of npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY package*.json ./
 COPY tsconfig.json ./
 
 # Install dependencies
-RUN npm ci
+RUN npm install
 
 # Copy source code
 COPY src ./src
@@ -23,7 +23,7 @@ WORKDIR /app
 
 # Install production dependencies only
 COPY package*.json ./
-RUN npm ci --only=production && npm cache clean --force
+RUN npm install --only=production && npm cache clean --force
 
 # Copy built application from builder
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
Updated both build stages to use npm install:
- Builder stage: npm install (for all dependencies)
- Production stage: npm install --only=production

This provides more flexibility for development environments where package-lock.json may not be present or needs to be regenerated.