### PR TITLE
Fix TypeScript template literal syntax errors in prompts.ts

### DIFF
--- a/src/ai/prompts.ts
+++ b/src/ai/prompts.ts
@@ -290,7 +290,7 @@ For each recommendation:
 
 ### 4. RECOMMENDED ACTIONS
 Provide 2-4 specific actions:
-```
+\`\`\`
 1. [Action 1]
    - Details: [Specific instructions]
    - Effort: Low/Medium/High
@@ -298,7 +298,7 @@ Provide 2-4 specific actions:
 
 2. [Action 2]
    ...
-```
+\`\`\`
 
 ### 5. EXPECTED IMPROVEMENT
 - Metric: [CTR/Retention/Engagement]
@@ -816,7 +816,7 @@ Analyze retention patterns and provide timestamp-specific recommendations to imp
 
 Based on retention analysis, here's the optimal structure for future videos in this niche:
 
-```
+\`\`\`
 [0:00-0:15] HOOK
 ├─ 0:00-0:03: Pattern interrupt (shocking stat, bold claim, visual)
 ├─ 0:04-0:08: Value promise (what viewer will learn/gain)
@@ -834,7 +834,7 @@ Based on retention analysis, here's the optimal structure for future videos in t
 ├─ [Timestamp]: Recap value delivered
 ├─ [Timestamp]: CTA (like, subscribe, next video)
 └─ [Timestamp]: End screen appears
-```
+\`\`\`
 
 **Optimal Video Length for This Content**: [X-Y minutes]
 **Rationale**: [Why this length]
@@ -1039,7 +1039,7 @@ Generate 10 Shorts concepts derived from existing long-form content:
 - Avoid: [Times/days to skip]
 
 **Content Calendar Template**:
-```
+\`\`\`
 Week 1:
 - Monday: [Short concept]
 - Wednesday: [Short concept]
@@ -1048,7 +1048,7 @@ Week 1:
 
 Week 2:
 [Pattern]
-```
+\`\`\`
 
 **Batching Strategy**:
 - [How to efficiently create multiple Shorts]


### PR DESCRIPTION
Escaped triple backticks (```) inside template literals to prevent premature string closure. The triple backticks were being used for markdown code blocks within the AI prompt templates, but they need to be escaped as \`\`\` when inside JavaScript/TypeScript template literals (strings delimited by backticks).

Fixed occurrences at:
- Lines 293, 301: VIDEO_ANALYSIS_PROMPT
- Lines 819, 837: RETENTION_OPTIMIZATION_PROMPT
- Lines 1042, 1051: SHORTS_STRATEGY_PROMPT

This resolves the TypeScript compilation errors that were preventing the Docker build from completing.

Errors fixed:
- TS1005: ']' expected, ';' expected
- TS1121: Octal literals are not allowed
- TS1127: Invalid character
- TS1128: Declaration or statement expected
- TS1434: Unexpected keyword or identifier