### PR TITLE
Remove obsolete version field from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # PostgreSQL Database
   postgres:


### PR DESCRIPTION
Docker Compose 2.x no longer requires the version field. This removes the deprecation warning.