### PR TITLE
Fix channelId redeclaration error in recommendation-engine

### DIFF
--- a/src/services/recommendation-engine.ts
+++ b/src/services/recommendation-engine.ts
@@ -160,7 +160,6 @@ export class RecommendationEngine {
       });
 
       // Parse AI response into recommendations
-      const channelId = channel.channelId || 'unknown';
       const recommendations = this.parseRecommendationsFromAI(
         result.content,
         channelId,


### PR DESCRIPTION
Removed duplicate const declaration of channelId variable on line 163 which was causing TypeScript compilation error TS2451. The variable was already declared on line 99 after validation, so the second declaration was redundant.