### PR TITLE
Fix error when analyzing new channel

### DIFF
--- a/frontend/src/pages/ChannelAnalysis.tsx
+++ b/frontend/src/pages/ChannelAnalysis.tsx
@@ -61,6 +61,9 @@ export function ChannelAnalysis() {
     setIsLoading(true);
     setError('');
     setChannelData(null);
+    setRecommendations([]);
+    setAlgorithmScore(null);
+    setLastSnapshotTimestamp(null);
 
     const startTime = performance.now();
 
@@ -151,6 +154,9 @@ export function ChannelAnalysis() {
         setLastSnapshotTimestamp(result.generatedAt);
         if (result.algorithmScore) {
           setAlgorithmScore(result.algorithmScore);
+        } else {
+          // Clear stale algorithm score from previous channel
+          setAlgorithmScore(null);
         }
         console.log('[ChannelAnalysis] Loaded existing recommendations and algorithm score from database');
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -387,7 +387,8 @@ app.post('/api/channels/:channelId/recommendations', async (req: Request, res: R
     });
 
     // Save recommendations and algorithm score to database
-    const generatedAt = new Date();
+    // Use the timestamp from the first recommendation to ensure consistency
+    const generatedAt = recommendations.length > 0 ? recommendations[0].createdAt : new Date();
     try {
       await recommendationsRepository.saveRecommendations(recommendations);
       await recommendationsRepository.saveAlgorithmScore(channelId, algorithmScore, generatedAt);


### PR DESCRIPTION
Fixed a timestamp mismatch bug where analyzing a new channel would display AI Performance data from a previously analyzed channel.

Root cause:
- Recommendations were created with timestamp T1
- Algorithm score was saved with different timestamp T2
- Database query failed to match T1 with T2, returning null
- Frontend didn't clear stale data when receiving null

Changes:
- server.ts: Use recommendation timestamp for algorithm score to ensure consistency
- ChannelAnalysis.tsx: Clear all state (recommendations, algorithm score) when analyzing new channel
- ChannelAnalysis.tsx: Clear stale algorithm score when fetching returns null

This ensures each channel analysis displays only its own data.